### PR TITLE
chore: update pip requirements to include spaceone-core version 1.12.37

### DIFF
--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -1,3 +1,4 @@
 google-auth
 google-api-python-client
 schematics
+spaceone-core==1.12.37


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [o] etc

### Description
 chore: update pip requirements to include spaceone-core version 1.12.37
### Known issue