### PR TITLE
chore: update pip requirements to replace spaceone-core with grpcio version 1.64.1

### DIFF
--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -1,4 +1,4 @@
 google-auth
 google-api-python-client
 schematics
-spaceone-core==1.12.37
+grpcio>=1.64.1

--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -1,4 +1,4 @@
 google-auth
 google-api-python-client
 schematics
-grpcio>=1.64.1
+grpcio>=1.64.1 


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [o] etc

### Description
 - chore: update pip requirements to replace spaceone-core with grpcio version 1.64.1
### Known issue